### PR TITLE
Fixed issue where some headers would come through with only 1 character

### DIFF
--- a/daphne/ws_protocol.py
+++ b/daphne/ws_protocol.py
@@ -4,6 +4,7 @@ import logging
 import time
 import traceback
 from six.moves.urllib.parse import urlencode
+from six import string_types
 
 from autobahn.twisted.websocket import WebSocketServerProtocol, WebSocketServerFactory
 
@@ -29,7 +30,10 @@ class WebSocketProtocol(WebSocketServerProtocol):
                 # Prevent CVE-2015-0219
                 if "_" in name:
                     continue
-                clean_headers[name.lower()] = value[0].encode("latin1")
+                if isinstance(value, string_types):
+                    clean_headers[name.lower()] = value.encode("latin1")
+                else:
+                    clean_headers[name.lower()] = value[0].encode("latin1")
             # Reconstruct query string
             # TODO: get autobahn to provide it raw
             query_string = urlencode(request.params).encode("ascii")


### PR DESCRIPTION
This change is to resolve an issue I was running into where quite a few headers would come through as only one character strings..

I ran into this issue with the following:

Python 3.5.1
CentOS 6.5

channels: commit 31447a4
asgiref: commit 1063feb
daphne: commit ba2bbff 

asgiref (0.9, /home/.../asgiref)
autobahn (0.12.1)
channels (0.8, /home/.../channels)
daphne (0.8.2, /home/.../daphne)
Django (1.9.2)
pip (8.0.2)
setuptools (20.1.1)
six (1.10.0)
Twisted (15.5.0)
txaio (2.2.1)
zope.interface (4.1.3)