### PR TITLE
Support inherited file descriptors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,21 @@ set a bind address and port (defaults to localhost, port 8000)::
     daphne -b 0.0.0.0 -p 8001 django_project.asgi:channel_layer
 
 
+If you intend to run daphne behind a proxy server you can use UNIX
+sockets to communicate between the two::
+
+    daphne -u /tmp/daphne.sock django_project.asgi:channel_layer
+
+
+If daphne is being run inside a process manager such as
+`Circus <https://github.com/circus-tent/circus/>`_ you might
+want it to bind to a file descriptor passed down from a parent process.
+To achieve this you can use the --fd flag::
+
+    daphne --fd 5 django_project.asgi:channel_layer
+
+To see all available command line options run daphne with the *-h* flag.
+
 Root Path (SCRIPT_NAME)
 -----------------------
 

--- a/daphne/cli.py
+++ b/daphne/cli.py
@@ -42,6 +42,13 @@ class CommandLineInterface(object):
             default=None,
         )
         self.parser.add_argument(
+            '--fd',
+            type=int,
+            dest='file_descriptor',
+            help='Bind to a file descriptor rather than a TCP host/port or named unix socket',
+            default=None,
+        )
+        self.parser.add_argument(
             '-v',
             '--verbosity',
             type=int,
@@ -133,6 +140,7 @@ class CommandLineInterface(object):
             host=args.host,
             port=args.port,
             unix_socket=args.unix_socket,
+            file_descriptor=args.file_descriptor,
             http_timeout=args.http_timeout,
             ping_interval=args.ping_interval,
             action_logger=AccessLogGenerator(access_log_stream) if access_log_stream else None,


### PR DESCRIPTION
I have tried running daphne both in https://github.com/circus-tent/circus/ and https://github.com/unbit/uwsgi
Both expose a file descriptor that is passed from the parent process to daphne, but daphne needs some tweaks to recognize the file descriptor as such.

Usage in circus is something like:

```
[watcher:daphne]
cmd = daphne --fd $(circus.sockets.daphne) <your.channel:layer>
singleton = True
use_sockets = True

[socket:daphne]
port=...
```
It's more complicated in uwsgi to get it to pass the raw socket.

Let me know what you think and I'll write some docs if this approach seems reasonable.
