### PR TITLE
Tell Twisted to keep producing data after connection upgrade

### DIFF
--- a/daphne/http_protocol.py
+++ b/daphne/http_protocol.py
@@ -110,6 +110,10 @@ class WebRequest(http.Request):
                     logger.debug("Connection %s did not get successful WS handshake.", self.reply_channel)
                 del self.factory.reply_protocols[self.reply_channel]
                 self.reply_channel = None
+
+                # Resume the producer so we keep getting data
+                self.channel.resumeProducing()
+
             # Boring old HTTP.
             else:
                 # Sanitize and decode headers, potentially extracting root path


### PR DESCRIPTION
Twisted 16.3 changed behaviour when all content is thought to be received. "Offending" code is at https://github.com/twisted/twisted/blob/twisted-16.3.0/twisted/web/http.py#L1841

Checked with Twisted 16.2 and it does not break it.

References #31 