### PR TITLE
Attach path to http.disconnect

### DIFF
--- a/daphne/http_protocol.py
+++ b/daphne/http_protocol.py
@@ -177,6 +177,7 @@ class WebRequest(http.Request):
         try:
             self.factory.channel_layer.send("http.disconnect", {
                 "reply_channel": self.reply_channel,
+                "path": self.unquote(self.path),
             })
         except self.factory.channel_layer.ChannelFull:
             pass

--- a/daphne/tests/test_http.py
+++ b/daphne/tests/test_http.py
@@ -66,3 +66,30 @@ class TestHTTPProtocol(TestCase):
         # Get the resulting message off of the channel layer, check root_path
         _, message = self.channel_layer.receive_many(["http.request"])
         self.assertEqual(message['root_path'], "/foobar /bar")
+
+    def test_http_disconnect_sets_path_key(self):
+        """
+        Tests http disconnect has the path key set, see http://channels.readthedocs.io/en/latest/asgi.html#disconnect
+        """
+        # Send a simple request to the protocol
+        self.proto.dataReceived(
+            b"GET /te%20st-%C3%A0/?foo=bar HTTP/1.1\r\n" +
+            b"Host: anywhere.com\r\n" +
+            b"\r\n"
+        )
+        # Get the request message
+        _, message = self.channel_layer.receive_many(["http.request"])
+
+        # Send back an example response
+        self.factory.dispatch_reply(
+            message['reply_channel'],
+            {
+                "status": 200,
+                "status_text": b"OK",
+                "content": b"DISCO",
+            }
+        )
+
+        # Get the disconnection notification
+        _, disconnect_message = self.channel_layer.receive_many(["http.disconnect"])
+        self.assertEqual(disconnect_message['path'], "/te st-à/")


### PR DESCRIPTION
Set a path key on http.disconnect so it can be routed like `http.request`
https://github.com/andrewgodwin/channels/issues/303